### PR TITLE
Increased the lifetime of the script in the cache.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.mail.jira.plugins</groupId>
     <artifactId>groovy</artifactId>
-    <version>1.21.3-jira8</version>
+    <version>1.21.4-jira8</version>
     <organization>
         <name>AtlasTeam</name>
         <url>https://atlasteam.ru/</url>

--- a/src/main/java/ru/mail/jira/plugins/groovy/impl/ScriptServiceImpl.java
+++ b/src/main/java/ru/mail/jira/plugins/groovy/impl/ScriptServiceImpl.java
@@ -56,7 +56,7 @@ public class ScriptServiceImpl implements ScriptService, PluginLifecycleAware {
     private final Cache<String, CompiledScript> scriptCache = Caffeine
         .newBuilder()
         .maximumSize(1000)
-        .expireAfterAccess(1, TimeUnit.HOURS)
+        .expireAfterAccess(12, TimeUnit.HOURS)
         .recordStats()
         .removalListener((String k, CompiledScript v, RemovalCause reason) -> {
             if (v != null) {

--- a/src/main/java/ru/mail/jira/plugins/groovy/impl/ScriptServiceImpl.java
+++ b/src/main/java/ru/mail/jira/plugins/groovy/impl/ScriptServiceImpl.java
@@ -55,7 +55,6 @@ public class ScriptServiceImpl implements ScriptService, PluginLifecycleAware {
     private final List<BindingProvider> bindingProviders = new ArrayList<>();
     private final Cache<String, CompiledScript> scriptCache = Caffeine
         .newBuilder()
-        .maximumSize(1000)
         .expireAfterAccess(12, TimeUnit.HOURS)
         .recordStats()
         .removalListener((String k, CompiledScript v, RemovalCause reason) -> {


### PR DESCRIPTION
Now scripts that have not been executed for more than an hour are cleared from the cache. Because of this, freezes occur during the day during the initialization of large scripts.